### PR TITLE
_wrap_methods filter by inspect.isfunction

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1383,7 +1383,7 @@ class HAClient(Client):
     @classmethod
     def _wrap_methods(cls):
         # Add HA support to all public Client methods, but only do this when we haven't done this before
-        for name, meth in inspect.getmembers(cls, inspect.ismethod):
+        for name, meth in inspect.getmembers(cls, inspect.isfunction):
             if not name.startswith("_"): # Only public methods
                 if inspect.isgeneratorfunction(meth):
                     setattr(cls, name, cls._ha_gen_method(meth))

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -63,7 +63,7 @@ class ClientTest(unittest2.TestCase):
         self.assertRaises(OutOfNNException, all, cat_result_gen)
 
     def test_wrapped_methods(self):
-        public_methods = [(name, method) for name, method in inspect.getmembers(HAClient, inspect.ismethod) if not name.startswith("_")]
+        public_methods = [(name, method) for name, method in inspect.getmembers(HAClient, inspect.isfunction) if not name.startswith("_")]
         self.assertGreater(len(public_methods), 0)
         wrapped_methods = [str(method) for name, method in public_methods if ".wrapped" in str(method)]
         self.assertEqual(len(public_methods), len(wrapped_methods))


### PR DESCRIPTION
Replace inspect.ismethod filter with inspect.isfunction filter for python 3 compatibility. fixes # 1