### PR TITLE
Allow Kerberos clients to work with Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
 
 extras_require = {
     'kerberos': [
-        'python-krbV',
+        'gssapi',
         'sasl']
 }
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ install_requires = [
 extras_require = {
     'kerberos': [
         'gssapi',
-        'sasl']
+        'pure-sasl']
 }
 
 tests_require = [

--- a/snakebite/channel.py
+++ b/snakebite/channel.py
@@ -193,7 +193,7 @@ class SocketRpcChannel(RpcChannel):
                 raise FatalException("Kerberos libs not found. Please install snakebite using 'pip install snakebite[kerberos]'")
 
             kerberos = Kerberos()
-            self.effective_user = effective_user or kerberos.user_principal().name
+            self.effective_user = effective_user or kerberos.user_principal()
         else: 
             self.effective_user = effective_user or get_current_username()
         self.sock_connect_timeout = sock_connect_timeout

--- a/snakebite/kerberos.py
+++ b/snakebite/kerberos.py
@@ -19,26 +19,29 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 '''
-kerberos.py - A very light wrapper around krbV
+kerberos.py - A very light wrapper around gssapi
 
 This package contains a class to read a kerberos principal
 
-May 2015
+May 2015 (original implementation with krbV)
 
 Bolke de Bruin (bolke@xs4all.nl)
+
+Nov 2019 (implementation with gssapi for Python3)
+
+Luca Toscano (toscano.luca@gmail.com)
 
 '''
 
 # python 3 support
 from __future__ import absolute_import, print_function, division
 
-import krbV
+import gssapi
 
 class Kerberos:
     def __init__(self):
-        self.ctx = krbV.default_context()
-        self.ccache = self.ctx.default_ccache()
+        self.credentials = gssapi.Credentials(usage='initiate')
 
     def user_principal(self):
-        return self.ccache.principal()
+        return str(self.credentials.inquire().name)
 

--- a/snakebite/rpc_sasl.py
+++ b/snakebite/rpc_sasl.py
@@ -114,7 +114,7 @@ class SaslRpcClient:
             initiate.token = initial_response
 
             for auth in res.auths:
-                if auth.mechanism == chosen_mech:
+                if auth.mechanism == chosen_mech.decode():
                     auth_method = initiate.auths.add()
                     auth_method.mechanism = chosen_mech
                     auth_method.method = auth.method


### PR DESCRIPTION
List of changes:

* While trying snakebite-py3 with other Kerberos libraries, I noticed
that SASL initialize was not able to use one of the available auth
mechanisms announced by the HDFS Namenode. The issue seems related
to a comparison between a text string and a bytes string.

* Replace the krbV, available only for Python 2, with gssapi.

* Add basic SASL + encryption support for the Hadoop RPC protocol (mostly Namenode requests).

Issue: #5