### PR TITLE
Catch StopIteration raised by generator

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1551,6 +1551,8 @@ class HAClient(Client):
                     self.__handle_request_error(e)
                 except socket.error as e:
                     self.__handle_socket_error(e)
+                except StopIteration as e:
+                    return e.value
         return wrapped
 
 HAClient._wrap_methods()


### PR DESCRIPTION
When running on python 3.7+ then generator raises `StopIteration` exception

```
  Traceback (most recent call last):
    File "[..]/lib/python3.7/site-packages/snakebite/client.py", line 1549, in wrapped
      yield next(results)
  StopIteration
```

This expected according to https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior
```
PEP 479 is enabled for all code in Python 3.7, meaning that StopIteration exceptions raised directly or indirectly in coroutines and generators are transformed into RuntimeError exceptions. 
```