### PR TITLE
fix IndexError raised by generator

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1523,6 +1523,11 @@ class HAClient(Client):
         else:
             raise
 
+    def __handle_index_error(self, exception):
+        log.debug("Request failed with %s" % exception)
+        # IndexError is raised when a NameNode is standby, so failover to another NN
+        next(self.namenode)
+
     @staticmethod
     def _ha_return_method(func):
         ''' Method decorator for 'return type' methods '''
@@ -1551,6 +1556,8 @@ class HAClient(Client):
                     self.__handle_request_error(e)
                 except socket.error as e:
                     self.__handle_socket_error(e)
+                except IndexError as e:
+                    self.__handle_index_error(e)
         return wrapped
 
 HAClient._wrap_methods()


### PR DESCRIPTION
HA generators raise an IndexError when a NameNode is in state Standby, this causes methods like ls to fail without trying to failover to another NameNode. Added a handler for IndexError in the method decorator.