### PR TITLE
Fix Python 3.8 compatibility issues

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 -r requirements.txt
 nose
 unittest2
-mock
+mock<4
 virtualenv>=1.11.2
 tox>=1.8.0
-sphinx
+sphinx<2
 sphinx_rtd_theme
 fig

--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1545,8 +1545,8 @@ class HAClient(Client):
             while(True): # switch between all namenodes
                 try:
                     results = func(self, *args, **kw)
-                    while(True): # yield all results
-                        yield next(results)
+                    yield from results
+                    break
                 except RequestError as e:
                     self.__handle_request_error(e)
                 except socket.error as e:

--- a/snakebite/formatter.py
+++ b/snakebite/formatter.py
@@ -90,19 +90,15 @@ def format_listing(listing, json_output=False, human_readable=False, recursive=F
     else:
         nodes = []
         last_dir = None
-        try:
-            while True:
-                node = next(listing)
-                dir_name = os.path.dirname(node['path'])
-                if dir_name != last_dir:
-                    if last_dir:
-                        yield _create_dir_listing(nodes, human_readable, recursive, summary)
-                    last_dir = dir_name
-                    nodes = []
-                nodes.append(node)
-
-        except StopIteration:
-            yield _create_dir_listing(nodes, human_readable, recursive, summary)
+        for node in listing:
+            dir_name = os.path.dirname(node['path'])
+            if dir_name != last_dir:
+                if last_dir:
+                    yield _create_dir_listing(nodes, human_readable, recursive, summary)
+                last_dir = dir_name
+                nodes = []
+            nodes.append(node)
+        yield _create_dir_listing(nodes, human_readable, recursive, summary)
 
 
 def _create_dir_listing(nodes, human_readable, recursive, summary):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py34,py35}-{cdh,hdp}
+envlist = {py26,py27,py34,py35,py36,py38}-{cdh,hdp}
 
 [testenv]
 usedevelop = True
@@ -9,6 +9,8 @@ basepython =
   py27: python2.7
   py34: python3.4
   py35: python3.5
+  py36: python3.6
+  py38: python3.8
 setenv =
   cdh: HADOOP_DISTRO=cdh
   cdh: HADOOP_HOME=/tmp/hadoop-cdh


### PR DESCRIPTION
In python 3.8, it is an error for generator to raise StopIteration. Fixed
sub iterator handling to make it work.
Added version constraint to requirements-dev.txt for older Python.
Added py36 and py38 tox envs.