### PR TITLE
chore: bump version to 3.0.6 to reflect python 3.8 compatibility fixes

### DIFF
--- a/snakebite/version.py
+++ b/snakebite/version.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, print_function, division
 
 
-VERSION = "3.0.5"
+VERSION = "3.0.6"
 
 def version():
     return VERSION


### PR DESCRIPTION
This PR bumps the version to `3.0.6` to reflect the Python 3.8 `StopIteration`-related fixes.